### PR TITLE
Use mergedGrid view for a faster loading experience.

### DIFF
--- a/examples/Create MoBIE Project.ipynb
+++ b/examples/Create MoBIE Project.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "# OME-Zarr plate we want to add to a MoBIE project\n",
-    "plate_path = \"zarr-files/Projection-Mix.zarr/\"\n",
+    "plate_path = \"./zarr-files/Projection-Mix.zarr/\"\n",
     "store = parse_url(plate_path, mode=\"r\").store\n",
     "    \n",
     "plate = zarr.group(store=store)"
@@ -148,12 +148,14 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "ba6e238b",
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9ba75ca17da4406ab479ae67f1a50724",
+       "model_id": "7f4ce87caa4b46c79401a52f566fb2cc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -197,7 +199,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ab0cbd89b5e40c38d6c843460566b3d",
+       "model_id": "b74e1d2c8f3b499787d1bbb472e63aa3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -245,8 +247,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Check sources for dataset Projection-Mix: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:00<00:00, 202.20it/s]\n",
-      "Check views for dataset Projection-Mix: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 26/26 [00:00<00:00, 65.47it/s]\n",
+      "Check sources for dataset Projection-Mix: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:00<00:00, 204.15it/s]\n",
+      "Check views for dataset Projection-Mix: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 69.79it/s]\n",
       "Check view files for dataset Projection-Mix: 0it [00:00, ?it/s]"
      ]
     },
@@ -359,7 +361,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9946345c52a44aa1a8c4a8b2d51fc25c",
+       "model_id": "4759c17f21ed4f818592640a853ab18a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -406,11 +408,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Check sources for dataset Projection-Mix: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:00<00:00, 208.70it/s]\n",
-      "Check views for dataset Projection-Mix: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 26/26 [00:00<00:00, 69.53it/s]\n",
+      "Check sources for dataset Projection-Mix: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 17/17 [00:00<00:00, 196.62it/s]\n",
+      "Check views for dataset Projection-Mix: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 69.92it/s]\n",
       "Check view files for dataset Projection-Mix: 0it [00:00, ?it/s]\n",
-      "Check sources for dataset Single-Plane: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 190.63it/s]\n",
-      "Check views for dataset Single-Plane: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 42.49it/s]\n",
+      "Check sources for dataset Single-Plane: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 182.72it/s]\n",
+      "Check views for dataset Single-Plane: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 67.90it/s]\n",
       "Check view files for dataset Single-Plane: 0it [00:00, ?it/s]"
      ]
     },


### PR DESCRIPTION
* Right-click show raw-images does not work for the whole plate-overview.
* Only the first channel and region-display are active by default.
* region-display is displayed as filled in squares.