### PR TITLE
Fix environment.yaml.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,7 +1,19 @@
-name: prefect-faim-hcs
+name: faim-hcs
+channels:
+  - conda-forge
+  - nodefaults
 dependencies:
   - python==3.9
   - conda-forge::mobie_utils==0.4.2
   - pip
+  - click
+  - cloudpickle
+  - dask 
+  - fasteners
+  - importlib-metadata
+  - jinja2
+  - locket 
+  - numcodecs
+  - ome-zarr
   - pip:
     - git+https://github.com/fmi-faim/faim-hcs@v0.2.2

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,11 +8,11 @@ dependencies:
   - pip
   - click
   - cloudpickle
-  - dask 
+  - dask
   - fasteners
   - importlib-metadata
   - jinja2
-  - locket 
+  - locket
   - numcodecs
   - ome-zarr
   - pip:


### PR DESCRIPTION
We wanted to install faim-hcs at ZIDAS and the existing environment.yaml was failing. This one works for us now.