### PR TITLE
Visiview stk acquisition

### DIFF
--- a/src/faim_hcs/dask_utils.py
+++ b/src/faim_hcs/dask_utils.py
@@ -1,6 +1,8 @@
 from multiprocessing import Process, Queue
 from time import sleep
 
+import numpy as np
+
 
 class LocalClusterFactory:
     """Creates a local dask cluster in a sub-process."""
@@ -91,3 +93,24 @@ class LocalClusterFactory:
             self._client = distributed.Client(self._get_scheduler_address())
 
         return self._client
+
+
+def mean_cast_to(target_dtype):
+    """
+    Wrap np.mean to cast the result to a given dtype.
+    """
+
+    def _mean(
+        a,
+        axis=None,
+        dtype=None,
+        out=None,
+        keepdims=np._NoValue,
+        *,
+        where=np._NoValue,
+    ):
+        return np.mean(
+            a=a, axis=axis, dtype=dtype, out=out, keepdims=keepdims, where=where
+        ).astype(target_dtype)
+
+    return _mean

--- a/src/faim_hcs/hcs/acquisition.py
+++ b/src/faim_hcs/hcs/acquisition.py
@@ -300,7 +300,8 @@ class WellAcquisition(ABC):
             tile_extents = []
             for tile in self._tiles:
                 tile_extents.append(
-                    tile.get_position() + np.array((1, 1, 1) + tile.shape)
+                    tile.get_position()
+                    + np.array((1,) * (5 - len(tile.shape)) + tile.shape)
                 )
             self._shape = tuple(np.max(tile_extents, axis=0))
 

--- a/src/faim_hcs/hcs/converter.py
+++ b/src/faim_hcs/hcs/converter.py
@@ -300,12 +300,23 @@ class ConvertToNGFFPlate:
     ):
         from faim_hcs.stitching import DaskTileStitcher
 
-        stitcher = DaskTileStitcher(
-            tiles=well_acquisition.get_tiles(),
-            yx_chunk_shape=(
+        tile_data_ndims = well_acquisition.get_tiles()[0].load_data().ndim
+        if tile_data_ndims == 2:
+            chunk_shape = (
                 chunks[-2],
                 chunks[-1],
-            ),
+            )
+        elif tile_data_ndims == 3:
+            chunk_shape = (
+                chunks[-3],
+                chunks[-2],
+                chunks[-1],
+            )
+        else:
+            raise NotImplementedError("Tile data must be 2D or 3D.")
+        stitcher = DaskTileStitcher(
+            tiles=well_acquisition.get_tiles(),
+            chunk_shape=chunk_shape,
             output_shape=output_shape,
             dtype=well_acquisition.get_dtype(),
         )

--- a/src/faim_hcs/hcs/converter.py
+++ b/src/faim_hcs/hcs/converter.py
@@ -313,7 +313,8 @@ class ConvertToNGFFPlate:
                 chunks[-1],
             )
         else:
-            raise NotImplementedError("Tile data must be 2D or 3D.")
+            raise NotImplementedError("Tile data must be 2D or 3D.")  # pragma: no cover
+
         stitcher = DaskTileStitcher(
             tiles=well_acquisition.get_tiles(),
             chunk_shape=chunk_shape,

--- a/src/faim_hcs/stitching/DaskTileStitcher.py
+++ b/src/faim_hcs/stitching/DaskTileStitcher.py
@@ -1,6 +1,6 @@
 from copy import copy
 from functools import partial
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import numpy as np
 from dask import array as da
@@ -18,7 +18,7 @@ class DaskTileStitcher:
     def __init__(
         self,
         tiles: list[Tile],
-        yx_chunk_shape: tuple[int, int],
+        chunk_shape: Union[tuple[int, int], tuple[int, int, int]],
         output_shape: Optional[tuple[int, int, int, int, int]] = None,
         dtype: np.dtype = np.uint16,
     ):
@@ -27,8 +27,8 @@ class DaskTileStitcher:
         ----------
         tiles :
             Tiles to stitch.
-        yx_chunk_shape :
-            Chunk shape in y and x.
+        chunk_shape :
+            Chunk shape in (Z)YX.
         output_shape :
             Shape of the output image. If None, the shape is computed from the tiles.
         dtype :
@@ -36,11 +36,7 @@ class DaskTileStitcher:
         """
         self.tiles: list[Tile] = stitching_utils.shift_to_origin(tiles)
 
-        self.chunk_shape = (
-            1,
-            1,
-            1,
-        ) + yx_chunk_shape
+        self.chunk_shape = (1,) * (5 - len(chunk_shape)) + chunk_shape
         self.dtype = dtype
 
         if output_shape is None:

--- a/src/faim_hcs/stitching/Tile.py
+++ b/src/faim_hcs/stitching/Tile.py
@@ -80,6 +80,24 @@ class Tile:
         Image data
         """
         data = imread(self.path)
+        data = self._apply_background_correction(data)
+        data = self._apply_illumination_correction(data)
+
+        return data
+
+    def _apply_illumination_correction(self, data):
+        dtype = data.dtype
+        if self.illumination_correction_matrix_path is not None:
+            icm = imread(self.illumination_correction_matrix_path)
+            assert icm.shape == data.shape, (
+                f"Illumination correction matrix shape {icm.shape} "
+                f"does not match image shape {data.shape}."
+            )
+            mi, ma = np.iinfo(dtype).min, np.iinfo(dtype).max
+            data = np.clip(data / icm, a_min=mi, a_max=ma).astype(dtype)
+        return data
+
+    def _apply_background_correction(self, data):
         dtype = data.dtype
         if self.background_correction_matrix_path is not None:
             bgcm = imread(self.background_correction_matrix_path)
@@ -89,14 +107,4 @@ class Tile:
             )
             mi, ma = np.iinfo(dtype).min, np.iinfo(dtype).max
             data = np.clip(data - bgcm, a_min=mi, a_max=ma).astype(dtype)
-
-        if self.illumination_correction_matrix_path is not None:
-            icm = imread(self.illumination_correction_matrix_path)
-            assert icm.shape == data.shape, (
-                f"Illumination correction matrix shape {icm.shape} "
-                f"does not match image shape {data.shape}."
-            )
-            mi, ma = np.iinfo(dtype).min, np.iinfo(dtype).max
-            data = np.clip(data / icm, a_min=mi, a_max=ma).astype(dtype)
-
         return data

--- a/src/faim_hcs/visiview/RegionAcquisition.py
+++ b/src/faim_hcs/visiview/RegionAcquisition.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+import pandas as pd
+from numpy._typing import NDArray
+from tifffile import TiffFile
+
+from faim_hcs.hcs.acquisition import TileAlignmentOptions, WellAcquisition
+from faim_hcs.stitching import Tile
+from faim_hcs.stitching.Tile import TilePosition
+from faim_hcs.visiview.StackedTile import StackedTile
+
+
+class RegionAcquisitionSTK(WellAcquisition):
+    def __init__(
+        self,
+        files: pd.DataFrame,
+        alignment: TileAlignmentOptions,
+        background_correction_matrices: Optional[dict[str, NDArray]],
+        illumination_correction_matrices: Optional[dict[str, NDArray]],
+        axes: list[str] = ["c", "z", "y", "x"],
+    ):
+        path = files.iloc[0]["path"]
+        with TiffFile(path) as tif:
+            metadata = tif.stk_metadata
+            if metadata is None:
+                raise ValueError(f"STK metadata is missing. Please check " f"{path}")
+            x_spacing = metadata["XCalibration"]
+            y_spacing = metadata["YCalibration"]
+            self._yx_spacing = (y_spacing, x_spacing)
+            self._z_spacing = metadata["ZDistance"].mean()
+            self._n_z_planes = metadata["NumberPlanes"]
+            self._yx_shape = tif.asarray().shape[-2:]
+
+        self._axes = axes
+        super().__init__(
+            files=files,
+            alignment=alignment,
+            background_correction_matrices=background_correction_matrices,
+            illumination_correction_matrices=illumination_correction_matrices,
+        )
+
+    def _assemble_tiles(self) -> list[Tile]:
+        tiles = []
+        for i, row in self._files.iterrows():
+            file = row["path"]
+            time_point = row["time"]
+            channel = row["channel"]
+
+            for z in range(self._n_z_planes):
+                tiles.append(
+                    StackedTile(
+                        path=file,
+                        shape=self._yx_shape,
+                        position=TilePosition(
+                            time=time_point,
+                            channel=channel,
+                            z=z,
+                            y=int(row["Y"] / self._yx_spacing[0]),
+                            x=int(row["X"] / self._yx_spacing[1]),
+                        ),
+                    )
+                )
+
+        return tiles
+
+    def get_z_spacing(self) -> Optional[float]:
+        return self._z_spacing
+
+    def get_yx_spacing(self) -> tuple[float, float]:
+        return self._yx_spacing
+
+    def get_axes(self) -> list[str]:
+        return self._axes

--- a/src/faim_hcs/visiview/RegionAcquisition.py
+++ b/src/faim_hcs/visiview/RegionAcquisition.py
@@ -28,8 +28,7 @@ class RegionAcquisitionSTK(WellAcquisition):
             y_spacing = metadata["YCalibration"]
             self._yx_spacing = (y_spacing, x_spacing)
             self._z_spacing = metadata["ZDistance"].mean()
-            self._n_z_planes = metadata["NumberPlanes"]
-            self._yx_shape = tif.asarray().shape[-2:]
+            self.tile_shape = tif.asarray().shape
 
         self._axes = axes
         super().__init__(
@@ -46,20 +45,19 @@ class RegionAcquisitionSTK(WellAcquisition):
             time_point = row["time"]
             channel = row["channel"]
 
-            for z in range(self._n_z_planes):
-                tiles.append(
-                    StackedTile(
-                        path=file,
-                        shape=self._yx_shape,
-                        position=TilePosition(
-                            time=time_point,
-                            channel=channel,
-                            z=z,
-                            y=int(row["Y"] / self._yx_spacing[0]),
-                            x=int(row["X"] / self._yx_spacing[1]),
-                        ),
-                    )
+            tiles.append(
+                StackedTile(
+                    path=file,
+                    shape=self.tile_shape,
+                    position=TilePosition(
+                        time=time_point,
+                        channel=channel,
+                        z=0,
+                        y=int(row["Y"] / self._yx_spacing[0]),
+                        x=int(row["X"] / self._yx_spacing[1]),
+                    ),
                 )
+            )
 
         return tiles
 

--- a/src/faim_hcs/visiview/StackedTile.py
+++ b/src/faim_hcs/visiview/StackedTile.py
@@ -6,7 +6,7 @@ from faim_hcs.stitching import Tile
 
 class StackedTile(Tile):
     def load_data(self) -> NDArray:
-        data = tifffile.memmap(self.path, mode="r")[self.position.z]
+        data = tifffile.memmap(self.path, mode="r")
 
         data = self._apply_background_correction(data)
         data = self._apply_illumination_correction(data)

--- a/src/faim_hcs/visiview/StackedTile.py
+++ b/src/faim_hcs/visiview/StackedTile.py
@@ -1,0 +1,14 @@
+from numpy._typing import NDArray
+from tifffile import TiffFile
+
+from faim_hcs.stitching import Tile
+
+
+class StackedTile(Tile):
+    def load_data(self) -> NDArray:
+        with TiffFile(self.path) as tif:
+            data = tif.asarray()[self.position.z]
+
+        data = self._apply_background_correction(data)
+        data = self._apply_illumination_correction(data)
+        return data

--- a/src/faim_hcs/visiview/StackedTile.py
+++ b/src/faim_hcs/visiview/StackedTile.py
@@ -1,13 +1,12 @@
+import tifffile
 from numpy._typing import NDArray
-from tifffile import TiffFile
 
 from faim_hcs.stitching import Tile
 
 
 class StackedTile(Tile):
     def load_data(self) -> NDArray:
-        with TiffFile(self.path) as tif:
-            data = tif.asarray()[self.position.z]
+        data = tifffile.memmap(self.path, mode="r")[self.position.z]
 
         data = self._apply_background_correction(data)
         data = self._apply_illumination_correction(data)

--- a/tests/hcs/test_converter.py
+++ b/tests/hcs/test_converter.py
@@ -8,6 +8,7 @@ import zarr
 from distributed import Client, LocalCluster
 from numcodecs import Blosc
 
+from faim_hcs import dask_utils
 from faim_hcs.hcs.acquisition import TileAlignmentOptions
 from faim_hcs.hcs.cellvoyager import StackAcquisition
 from faim_hcs.hcs.converter import ConvertToNGFFPlate, NGFFPlate
@@ -126,7 +127,7 @@ def test__get_storage_options():
 
 
 def test__mean_cast_to():
-    mean_cast_to = ConvertToNGFFPlate._mean_cast_to(np.uint8)
+    mean_cast_to = dask_utils.mean_cast_to(np.uint8)
     input = np.array([1.0, 2.0], dtype=np.float32)
     assert input.dtype == np.float32
     assert mean_cast_to(input).dtype == np.uint8

--- a/tests/stitching/test_TileStitcher.py
+++ b/tests/stitching/test_TileStitcher.py
@@ -48,7 +48,7 @@ def test_block_to_tile_map(tiles):
     """
     ts = DaskTileStitcher(
         tiles=tiles,
-        yx_chunk_shape=(10, 10),
+        chunk_shape=(10, 10),
     )
 
     assert ts._shape == (1, 1, 1, 20, 20)
@@ -66,7 +66,7 @@ def test_block_to_tile_map_large_chunks(tiles):
     """
     ts = DaskTileStitcher(
         tiles=tiles,
-        yx_chunk_shape=(15, 15),
+        chunk_shape=(15, 15),
     )
 
     assert ts._shape == (1, 1, 1, 20, 20)
@@ -89,7 +89,7 @@ def test_block_to_tile_map_small_chunks(tiles):
     """
     ts = DaskTileStitcher(
         tiles=tiles,
-        yx_chunk_shape=(8, 8),
+        chunk_shape=(8, 8),
     )
 
     assert ts._shape == (1, 1, 1, 20, 20)
@@ -111,7 +111,7 @@ def test_block_to_tile_map_small_chunks(tiles):
 
 
 def test_stitch_exact(tiles):
-    ts = DaskTileStitcher(tiles=tiles, yx_chunk_shape=(7, 7))
+    ts = DaskTileStitcher(tiles=tiles, chunk_shape=(7, 7))
     stitched = ts.get_stitched_image(
         transform_func=stitching_utils.translate_tiles_2d,
         fuse_func=stitching_utils.fuse_sum,
@@ -160,7 +160,7 @@ def overlapping_tiles():
 
 
 def test_stitch_overlapping(overlapping_tiles):
-    ts = DaskTileStitcher(tiles=overlapping_tiles, yx_chunk_shape=(5, 7))
+    ts = DaskTileStitcher(tiles=overlapping_tiles, chunk_shape=(5, 7))
     stitched = ts.get_stitched_image(
         transform_func=stitching_utils.translate_tiles_2d,
         fuse_func=stitching_utils.fuse_sum,

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -182,11 +182,47 @@ def test_shift_to_origin():
     assert result[0].get_position() == (0, 0, 0, 0, 0)
 
 
-def test_translate_tiles_2d(tiles):
+def test_translate_3d_tiles_2d(tiles):
     tile_map = {
         (0, 0, 0, 0, 0): [
             DummyTile(yx_position=(0, 0), data=tiles[0][..., :15]),
             DummyTile(yx_position=(0, 5), data=tiles[1][..., 5:]),
+        ],
+        (1, 0, 0, 0, 0): [],
+    }
+
+    block_info = {
+        None: {
+            "array-location": [(0, 1), (0, 1), (0, 1), (0, 10), (0, 20)],
+            "chunk-location": (0, 0, 0, 0, 0),
+            "chunk-shape": (1, 1, 1, 10, 20),
+            "dtype": "uint16",
+            "num-chunks": (1, 1, 1, 1, 1),
+            "shape": (1, 1, 1, 10, 20),
+        }
+    }
+
+    warped_tiles, warped_masks = translate_tiles_2d(
+        block_info=block_info,
+        chunk_shape=(1, 10, 20),
+        tiles=tile_map[(0, 0, 0, 0, 0)],
+    )
+
+    assert warped_tiles.shape == (2, 1, 10, 20)
+    assert warped_masks.shape == (2, 1, 10, 20)
+
+    assert warped_tiles.dtype == np.uint16
+    assert warped_masks.dtype == bool
+
+    assert_array_equal(warped_tiles[0], tiles[0])
+    assert_array_equal(warped_tiles[1], tiles[1])
+
+
+def test_translate_2d_tiles_2d(tiles):
+    tile_map = {
+        (0, 0, 0, 0, 0): [
+            DummyTile(yx_position=(0, 0), data=tiles[0][0, ..., :15]),
+            DummyTile(yx_position=(0, 5), data=tiles[1][0, ..., 5:]),
         ],
         (1, 0, 0, 0, 0): [],
     }

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -11,67 +11,67 @@ from faim_hcs.stitching.stitching_utils import (
     fuse_mean,
     fuse_sum,
     shift_to_origin,
+    shift_yx,
     translate_tiles_2d,
-    warp_yx,
 )
 from faim_hcs.stitching.Tile import TilePosition
 
 
 @pytest.fixture
 def tiles():
-    t1 = np.zeros((10, 20), dtype=np.uint16)
-    t1[:, :15] = 1
-    t2 = np.zeros((10, 20), dtype=np.uint16)
-    t2[:, 5:] = 4
+    t1 = np.zeros((1, 10, 20), dtype=np.uint16)
+    t1[:, :, :15] = 1
+    t2 = np.zeros((1, 10, 20), dtype=np.uint16)
+    t2[:, :, 5:] = 4
     return np.array([t1, t2])
 
 
 @pytest.fixture
 def masks():
-    t1 = np.zeros((10, 20), dtype=bool)
-    t1[:, :15] = True
-    t2 = np.zeros((10, 20), dtype=bool)
-    t2[:, 5:] = True
+    t1 = np.zeros((1, 10, 20), dtype=bool)
+    t1[:, :, :15] = True
+    t2 = np.zeros((1, 10, 20), dtype=bool)
+    t2[:, :, 5:] = True
     return np.array([t1, t2])
 
 
 def test_fuse_mean(tiles, masks):
     fused_result = fuse_mean(warped_tiles=tiles, warped_masks=masks)
-    assert fused_result.shape == (10, 20)
+    assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
-    assert_array_equal(fused_result[:, :5], 1)
-    assert_array_equal(fused_result[:, 5:15], 2)
-    assert_array_equal(fused_result[:, 15:], 4)
+    assert_array_equal(fused_result[:, :, :5], 1)
+    assert_array_equal(fused_result[:, :, 5:15], 2)
+    assert_array_equal(fused_result[:, :, 15:], 4)
 
 
 def test_fuse_sum(tiles, masks):
     fused_result = fuse_sum(warped_tiles=tiles, warped_masks=masks)
-    assert fused_result.shape == (10, 20)
+    assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
-    assert_array_equal(fused_result[:, :5], 1)
-    assert_array_equal(fused_result[:, 5:15], 5)
-    assert_array_equal(fused_result[:, 15:], 4)
+    assert_array_equal(fused_result[:, :, :5], 1)
+    assert_array_equal(fused_result[:, :, 5:15], 5)
+    assert_array_equal(fused_result[:, :, 15:], 4)
 
 
 def test_fuse_linear(tiles, masks):
     fused_result = fuse_linear(warped_tiles=tiles, warped_masks=masks)
-    assert fused_result.shape == (10, 20)
+    assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
-    assert_array_equal(fused_result[:, :5], 1)
-    assert_array_equal(fused_result[:, 5], int(1 * 10 / 11 + 4 * 1 / 11))
-    assert_array_equal(fused_result[:, 6], int(1 * 9 / 11 + 4 * 2 / 11))
-    assert_array_equal(fused_result[:, 7], int(1 * 8 / 11 + 4 * 3 / 11))
-    assert_array_equal(fused_result[:, 8], int(1 * 7 / 11 + 4 * 4 / 11))
-    assert_array_equal(fused_result[:, 9], int(1 * 6 / 11 + 4 * 5 / 11))
-    assert_array_equal(fused_result[:, 10], int(1 * 5 / 11 + 4 * 6 / 11))
-    assert_array_equal(fused_result[:, 11], int(1 * 4 / 11 + 4 * 7 / 11))
-    assert_array_equal(fused_result[:, 12], int(1 * 3 / 11 + 4 * 8 / 11))
-    assert_array_equal(fused_result[:, 13], int(1 * 2 / 11 + 4 * 9 / 11))
-    assert_array_equal(fused_result[:, 14], int(1 * 1 / 11 + 4 * 10 / 11))
-    assert_array_equal(fused_result[:, 15:], 4)
+    assert_array_equal(fused_result[:, :, :5], 1)
+    assert_array_equal(fused_result[:, :, 5], int(1 * 10 / 11 + 4 * 1 / 11))
+    assert_array_equal(fused_result[:, :, 6], int(1 * 9 / 11 + 4 * 2 / 11))
+    assert_array_equal(fused_result[:, :, 7], int(1 * 8 / 11 + 4 * 3 / 11))
+    assert_array_equal(fused_result[:, :, 8], int(1 * 7 / 11 + 4 * 4 / 11))
+    assert_array_equal(fused_result[:, :, 9], int(1 * 6 / 11 + 4 * 5 / 11))
+    assert_array_equal(fused_result[:, :, 10], int(1 * 5 / 11 + 4 * 6 / 11))
+    assert_array_equal(fused_result[:, :, 11], int(1 * 4 / 11 + 4 * 7 / 11))
+    assert_array_equal(fused_result[:, :, 12], int(1 * 3 / 11 + 4 * 8 / 11))
+    assert_array_equal(fused_result[:, :, 13], int(1 * 2 / 11 + 4 * 9 / 11))
+    assert_array_equal(fused_result[:, :, 14], int(1 * 1 / 11 + 4 * 10 / 11))
+    assert_array_equal(fused_result[:, :, 15:], 4)
 
     fused_result = fuse_linear(warped_tiles=tiles[:1], warped_masks=masks[:1])
-    assert fused_result.shape == (10, 20)
+    assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result, tiles[0])
 
@@ -82,8 +82,8 @@ class DummyTile:
         self._yx_position = yx_position
         self._data = data
 
-    def get_yx_position(self):
-        return self._yx_position
+    def get_zyx_position(self):
+        return (0,) + self._yx_position
 
     def load_data(self):
         return self._data
@@ -117,7 +117,7 @@ def test_assemble_chunk(tiles):
         dtype=np.uint16,
     )
     assert stitched_img.shape == (1, 1, 1, 10, 20)
-    assert_array_equal(stitched_img[0, 0, 0], tiles[0] + tiles[1])
+    assert_array_equal(stitched_img[0, 0], tiles[0] + tiles[1])
 
     block_info = {
         None: {
@@ -137,7 +137,7 @@ def test_assemble_chunk(tiles):
         dtype=np.uint16,
     )
     assert stitched_img.shape == (1, 1, 1, 10, 20)
-    assert_array_equal(stitched_img[0, 0, 0], np.zeros_like(tiles[0], dtype=np.uint16))
+    assert_array_equal(stitched_img[0, 0], np.zeros_like(tiles[0], dtype=np.uint16))
 
     tile_map = {
         (0, 0, 0, 0, 0): [
@@ -165,7 +165,7 @@ def test_assemble_chunk(tiles):
         dtype=np.uint16,
     )
     assert stitched_img.shape == (1, 1, 1, 10, 20)
-    assert_array_equal(stitched_img[0, 0, 0], tiles[0])
+    assert_array_equal(stitched_img[0, 0], tiles[0])
 
 
 def test_shift_to_origin():
@@ -204,13 +204,12 @@ def test_translate_tiles_2d(tiles):
 
     warped_tiles, warped_masks = translate_tiles_2d(
         block_info=block_info,
-        yx_chunk_shape=(10, 20),
-        dtype=np.uint16,
+        chunk_shape=(1, 10, 20),
         tiles=tile_map[(0, 0, 0, 0, 0)],
     )
 
-    assert warped_tiles.shape == (2, 10, 20)
-    assert warped_masks.shape == (2, 10, 20)
+    assert warped_tiles.shape == (2, 1, 10, 20)
+    assert warped_masks.shape == (2, 1, 10, 20)
 
     assert warped_tiles.dtype == np.uint16
     assert warped_masks.dtype == bool
@@ -220,66 +219,66 @@ def test_translate_tiles_2d(tiles):
 
 
 def test_warp_yx():
-    tile_data = np.ones((3, 3))
-    yx_chunk_shape = (3, 3)
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
+    tile_data = np.ones((1, 3, 3))
+    chunk_shape = (1, 3, 3)
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
-        tile_origin=np.array((0, 0)),
-        yx_chunk_shape=yx_chunk_shape,
+        tile_origin=np.array((0, 0, 0)),
+        chunk_shape=chunk_shape,
     )
     assert_array_equal(warped_tile, tile_data)
-    assert_array_equal(warped_mask, np.ones((3, 3), dtype=bool))
+    assert_array_equal(warped_mask, np.ones((1, 3, 3), dtype=bool))
 
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
-        tile_origin=np.array((-1, -1)),
-        yx_chunk_shape=yx_chunk_shape,
+        tile_origin=np.array((0, -1, -1)),
+        chunk_shape=chunk_shape,
     )
     expected_warped_tile = np.zeros_like(tile_data)
-    expected_warped_tile[:-1, :-1] = 1
+    expected_warped_tile[:, :-1, :-1] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
     assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
-        tile_origin=np.array((1, 1)),
-        yx_chunk_shape=yx_chunk_shape,
+        tile_origin=np.array((0, 1, 1)),
+        chunk_shape=chunk_shape,
     )
     expected_warped_tile = np.zeros_like(tile_data)
-    expected_warped_tile[1:, 1:] = 1
+    expected_warped_tile[:, 1:, 1:] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
     assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
-        tile_data=np.ones((1, 1)),
-        tile_origin=np.array((1, 1)),
-        yx_chunk_shape=yx_chunk_shape,
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
+        tile_data=np.ones((1, 1, 1)),
+        tile_origin=np.array((0, 1, 1)),
+        chunk_shape=chunk_shape,
     )
-    expected_warped_tile = np.zeros((3, 3))
-    expected_warped_tile[1, 1] = 1
+    expected_warped_tile = np.zeros((1, 3, 3))
+    expected_warped_tile[0, 1, 1] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
     assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
-        tile_data=np.ones((5, 5)),
-        tile_origin=np.array((-1, -1)),
-        yx_chunk_shape=yx_chunk_shape,
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
+        tile_data=np.ones((1, 5, 5)),
+        tile_origin=np.array((0, -1, -1)),
+        chunk_shape=chunk_shape,
     )
-    expected_warped_tile = np.ones((3, 3))
+    expected_warped_tile = np.ones((1, 3, 3))
     assert_array_equal(warped_tile, expected_warped_tile)
     assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = warp_yx(
-        chunk_yx_origin=np.array((0, 0)),
-        tile_data=np.ones((5, 5)),
-        tile_origin=np.array((6, 0)),
-        yx_chunk_shape=yx_chunk_shape,
+    warped_tile, warped_mask = shift_yx(
+        chunk_zyx_origin=np.array((0, 0, 0)),
+        tile_data=np.ones((1, 5, 5)),
+        tile_origin=np.array((0, 6, 0)),
+        chunk_shape=chunk_shape,
     )
-    expected_warped_tile = np.zeros((3, 3))
+    expected_warped_tile = np.zeros((1, 3, 3))
     assert_array_equal(warped_tile, expected_warped_tile)
     assert_array_equal(warped_mask, expected_warped_tile == 1)


### PR DESCRIPTION
Add support to convert Visiview STK acquisitions to ome-zarr multiscale images. This is used here: https://github.com/fmi-basel/ggrossha_GRH1_NHR23/tree/main/ipa/s01_convert_to_zarr

I changed the `DaskTileStitcher` to work with 2D and 3D tile data. In both cases the tile-data is only shifted in YX. This improves performance for STK acquisitions where the acquired raw-data is stored in 3D stacks. 