### PR TITLE
Fix shape missmatch and compute binary mask indicating acquired data

### DIFF
--- a/src/faim_hcs/hcs/cellvoyager/StackedTile.py
+++ b/src/faim_hcs/hcs/cellvoyager/StackedTile.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
+from numpy._typing import NDArray
 from tifffile import imread
 
 from faim_hcs.stitching import Tile
@@ -37,5 +38,13 @@ class StackedTile(Tile):
                 plane = self._apply_background_correction(plane)
                 plane = self._apply_illumination_correction(plane)
                 data[i] = plane
+
+        return data
+
+    def load_data_mask(self) -> NDArray:
+        data = np.zeros(self.shape, dtype=bool)
+        for i, path in enumerate(self._paths):
+            if path:
+                data[i] = True
 
         return data

--- a/src/faim_hcs/hcs/converter.py
+++ b/src/faim_hcs/hcs/converter.py
@@ -340,7 +340,9 @@ class ConvertToNGFFPlate:
         )
         image_da = stitcher.get_stitched_dask_array(
             warp_func=self._warp_func,
-            fuse_func=self._fuse_func,
+            fuse_func=(
+                stitching_utils.fuse_sum if build_acquisition_mask else self._fuse_func
+            ),
             build_acquisition_mask=build_acquisition_mask,
         )
         return image_da

--- a/src/faim_hcs/hcs/converter.py
+++ b/src/faim_hcs/hcs/converter.py
@@ -123,6 +123,7 @@ class ConvertToNGFFPlate:
         chunks: Union[tuple[int, int], tuple[int, int, int]] = (2048, 2048),
         max_layer: int = 3,
         storage_options: dict = None,
+        build_acquisition_mask: bool = False,
     ):
         """
         Convert a plate acquisition to an NGFF plate.
@@ -139,6 +140,8 @@ class ConvertToNGFFPlate:
             Maximum layer of the resolution pyramid layers.
         storage_options :
             Zarr storage options.
+        build_acquisition_mask :
+            Writes a boolean mask instead of the image data, indicating where the image data is present.
 
         Returns
         -------
@@ -163,6 +166,7 @@ class ConvertToNGFFPlate:
                 plate_acquisition,
                 storage_options,
                 well_acquisition,
+                build_acquisition_mask=build_acquisition_mask,
             )
             shapes, datasets = self._build_pyramid(
                 group,
@@ -215,11 +219,13 @@ class ConvertToNGFFPlate:
         plate_acquisition,
         storage_options,
         well_acquisition,
+        build_acquisition_mask,
     ):
         stitched_well_da = self._stitch_well_image(
             chunks,
             well_acquisition,
             output_shape=plate_acquisition.get_common_well_shape(),
+            build_acquisition_mask=build_acquisition_mask,
         )
         binned_da = self._bin_yx(stitched_well_da).squeeze()
         rechunked_da = binned_da.rechunk(self._out_chunks(binned_da.shape, chunks))
@@ -307,6 +313,7 @@ class ConvertToNGFFPlate:
         chunks,
         well_acquisition,
         output_shape: tuple[int, int, int, int, int],
+        build_acquisition_mask: bool,
     ):
         from faim_hcs.stitching import DaskTileStitcher
 
@@ -329,11 +336,12 @@ class ConvertToNGFFPlate:
             tiles=well_acquisition.get_tiles(),
             chunk_shape=chunk_shape,
             output_shape=output_shape,
-            dtype=well_acquisition.get_dtype(),
+            dtype=bool if build_acquisition_mask else well_acquisition.get_dtype(),
         )
         image_da = stitcher.get_stitched_dask_array(
             warp_func=self._warp_func,
             fuse_func=self._fuse_func,
+            build_acquisition_mask=build_acquisition_mask,
         )
         return image_da
 

--- a/src/faim_hcs/stitching/DaskTileStitcher.py
+++ b/src/faim_hcs/stitching/DaskTileStitcher.py
@@ -109,6 +109,7 @@ class DaskTileStitcher:
         self,
         warp_func: Callable = stitching_utils.translate_tiles_2d,
         fuse_func: Callable = stitching_utils.fuse_mean,
+        build_acquisition_mask: bool = False,
     ) -> da.array:
         """
         Build the dask array for the stitched image.
@@ -128,6 +129,7 @@ class DaskTileStitcher:
             stitching_utils.assemble_chunk,
             warp_func=warp_func,
             fuse_func=fuse_func,
+            build_acquisition_mask=build_acquisition_mask,
         )
 
         return da.map_blocks(

--- a/src/faim_hcs/stitching/Tile.py
+++ b/src/faim_hcs/stitching/Tile.py
@@ -85,6 +85,16 @@ class Tile:
 
         return data
 
+    def load_data_mask(self) -> NDArray:
+        """
+        Create a binary mask indicating the presence of data.
+
+        Returns
+        -------
+        Binary mask
+        """
+        return np.ones(self.shape, dtype=bool)
+
     def _apply_illumination_correction(self, data):
         dtype = data.dtype
         if self.illumination_correction_matrix_path is not None:

--- a/src/faim_hcs/stitching/stitching_utils.py
+++ b/src/faim_hcs/stitching/stitching_utils.py
@@ -159,8 +159,8 @@ def shift_yx(chunk_zyx_origin, tile_data, tile_origin, chunk_shape):
         end_y = start_y + tile_data.shape[1]
         start_x = max(0, yx_shift[1])
         end_x = start_x + tile_data.shape[2]
-        warped_tile[..., start_y:end_y, start_x:end_x] = tile_data
-        warped_mask[..., start_y:end_y, start_x:end_x] = True
+        warped_tile[: tile_data.shape[0], start_y:end_y, start_x:end_x] = tile_data
+        warped_mask[: tile_data.shape[0], start_y:end_y, start_x:end_x] = True
     return warped_mask, warped_tile
 
 


### PR DESCRIPTION
1. Fix shape missmatch: We create the well-shape such that all wells are of a plate are fully covered. For some wells this leads to larger wells than what we have acquired (e.g. in Z with corrected auto-focus). We need to account for this when we prepare the `StackedTile`s to ensure that the returned image data fits into the chunks produced by `map_blocks`.
2. Add an option to write a binary image instead of the real image data for all positions where data is available. 