### PR TITLE
ZAdjustedStackAcq: don't fail on unrelated files

### DIFF
--- a/resources/CV8000/CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_20230918_135839/TRACE-incomplete.log
+++ b/resources/CV8000/CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_20230918_135839/TRACE-incomplete.log
@@ -1,3 +1,4 @@
+0000/00/00,00:00:00,.000,-35533593,Portal,RemoteDevice,ReaderControl,--->,AF_MANU,34,0,OK,3.0,0
 0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_D08_T0001F001L01A01Z01C01.tif,None
 0000/00/00,00:00:00,.000,-35533593,Portal,RemoteDevice,ReaderControl,--->,AF_MANU,34,0,OK,3.0,0
 0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_D08_T0001F001L01A01Z02C01.tif,None

--- a/resources/CV8000/CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_20230918_135839/TRACE2023-XX-XX.log
+++ b/resources/CV8000/CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_20230918_135839/TRACE2023-XX-XX.log
@@ -6,6 +6,7 @@
 0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_D08_T0001F001L01A01Z03C01.tif,None
 0000/00/00,00:00:00,.000,-35533593,Portal,RemoteDevice,ReaderControl,--->,AF_MANU,34,0,OK,9.0,0
 0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_D08_T0001F001L01A01Z04C01.tif,None
+0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,this-file-does-not-have-z-position-information.tif,None
 0000/00/00,00:00:00,.000,-35533593,Portal,RemoteDevice,ReaderControl,--->,AF_MANU,34,0,OK,0.0,0
 0000/00/00,00:00:00,.000,-35533750,Measurement,Measurement.measure_timelapse,_m_Timelapse,_init_frame_save,CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_D08_T0001F001L01A02Z01C02.tif,None
 0000/00/00,00:00:00,.000,-35533593,Portal,RemoteDevice,ReaderControl,--->,AF_MANU,34,0,OK,3.0,0

--- a/tests/hcs/cellvoyager/test_ZAdjustedStackAcquisition.py
+++ b/tests/hcs/cellvoyager/test_ZAdjustedStackAcquisition.py
@@ -32,13 +32,13 @@ def trace_log_file() -> Path:
 
 
 @pytest.fixture
-def invalid_trace_log_file() -> Path:
+def incomplete_trace_log_file() -> Path:
     return (
         Path(__file__).parent.parent.parent.parent
         / "resources"
         / "CV8000"
         / "CV8000-Minimal-DataSet-2C-3W-4S-FP2-stack_20230918_135839"
-        / "TRACE-invalid.log"
+        / "TRACE-incomplete.log"
     )
 
 
@@ -117,12 +117,10 @@ def test_get_well_acquisitions(cv_acquisition, trace_log_file):
             assert tile.position.z in [0, 1, 2, 3, 4, 5]
 
 
-def test_invalid_tracelog(cv_acquisition, invalid_trace_log_file):
-    with pytest.raises(
-        ValueError, match="At least one invalid z position"
-    ), pytest.warns(UserWarning, match="First file without z position"):
+def test_incomplete_tracelog(cv_acquisition, incomplete_trace_log_file):
+    with pytest.raises(ValueError, match="At least one invalid z position"):
         ZAdjustedStackAcquisition(
             acquisition_dir=cv_acquisition,
-            trace_log_files=[invalid_trace_log_file],
+            trace_log_files=[incomplete_trace_log_file],
             alignment=TileAlignmentOptions.GRID,
         )

--- a/tests/hcs/cellvoyager/test_ZAdjustedStackAcquisition.py
+++ b/tests/hcs/cellvoyager/test_ZAdjustedStackAcquisition.py
@@ -43,11 +43,12 @@ def invalid_trace_log_file() -> Path:
 
 
 def test__parse_files(cv_acquisition, trace_log_file):
-    plate = ZAdjustedStackAcquisition(
-        acquisition_dir=cv_acquisition,
-        trace_log_files=[trace_log_file],
-        alignment=TileAlignmentOptions.GRID,
-    )
+    with pytest.warns(UserWarning, match="First file without z position"):
+        plate = ZAdjustedStackAcquisition(
+            acquisition_dir=cv_acquisition,
+            trace_log_files=[trace_log_file],
+            alignment=TileAlignmentOptions.GRID,
+        )
 
     files = plate._parse_files()
     assert len(files) == 96
@@ -86,11 +87,12 @@ def test__parse_files(cv_acquisition, trace_log_file):
 
 
 def test_get_well_acquisitions(cv_acquisition, trace_log_file):
-    plate = ZAdjustedStackAcquisition(
-        acquisition_dir=cv_acquisition,
-        trace_log_files=[trace_log_file],
-        alignment=TileAlignmentOptions.GRID,
-    )
+    with pytest.warns(UserWarning, match="First file without z position"):
+        plate = ZAdjustedStackAcquisition(
+            acquisition_dir=cv_acquisition,
+            trace_log_files=[trace_log_file],
+            alignment=TileAlignmentOptions.GRID,
+        )
 
     wells = plate.get_well_acquisitions()
     assert len(wells) == 3
@@ -116,7 +118,9 @@ def test_get_well_acquisitions(cv_acquisition, trace_log_file):
 
 
 def test_invalid_tracelog(cv_acquisition, invalid_trace_log_file):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="At least one invalid z position"
+    ), pytest.warns(UserWarning, match="First file without z position"):
         ZAdjustedStackAcquisition(
             acquisition_dir=cv_acquisition,
             trace_log_files=[invalid_trace_log_file],


### PR DESCRIPTION
We now issue a warning if files without an associated z position are found in the trace log file, but only fail if any of the dataset files has a NaN position after merging.