### PR TITLE
Squeeze missing axes.

### DIFF
--- a/src/faim_hcs/hcs/converter.py
+++ b/src/faim_hcs/hcs/converter.py
@@ -234,7 +234,14 @@ class ConvertToNGFFPlate:
             output_shape=plate_acquisition.get_common_well_shape(),
             build_acquisition_mask=build_acquisition_mask,
         )
-        binned_da = self._bin_yx(stitched_well_da).squeeze()
+        drop_axes = tuple(
+            i
+            for i, s in enumerate(["t", "c", "z", "y", "x"])
+            if s not in well_acquisition.get_axes()
+        )
+        binned_da = self._bin_yx(stitched_well_da)
+        if len(drop_axes) > 0:
+            binned_da = binned_da.squeeze(drop_axes)
         rechunked_da = binned_da.rechunk(self._out_chunks(binned_da.shape, chunks))
         options = self._get_storage_options(storage_options, rechunked_da.shape, chunks)
         wait(


### PR DESCRIPTION
Before we squeezed all axes which had size == 1. This also dropped the channel axes for single channel images.